### PR TITLE
[2단계 - 계산기] 태태(김태윤) 미션 제출합니다.

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -11,8 +11,6 @@
 - [x] 연산의 결과값이 Infinity일 경우 오류라는 문자열을 보여준다. (아이폰 참고)
 
 - [x] 출력값 있는 상황에 사용자의 페이지 이탈시 confirm을 활용해 사용자의 이탈
-      여부를 확인한다. (componentWillUnMount)
+      여부를 확인한다.
 - [x] 항상 사용자의 이탈시 마지막 출력값을 Local Storage에 저장한다.
-      (componentWillUnMount)
 - [x] 초기 로딩시 이전 값이 Local Storage에 존재한다면 초기 값으로 적용한다.
-      (componentDidMount)

--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,12 @@ body {
   font-family: sans-serif;
 }
 
+button {
+  font-size: 2rem;
+  border: 0.5px solid #98999b;
+  cursor: pointer;
+}
+
 #app {
   height: 100vh;
   display: flex;
@@ -27,23 +33,6 @@ body {
   height: 500px;
 }
 
-button {
-  font-size: 2rem;
-  border: 0.5px solid #98999b;
-}
-
-.modifiers button {
-  background-color: #ccc;
-}
-
-.operations button {
-  background-color: orange;
-}
-
-.digits button {
-  background-color: #efefef;
-}
-
 #total {
   grid-area: total;
   background-color: #333;
@@ -56,6 +45,20 @@ button {
   font-size: 4rem;
 }
 
+.modifiers {
+  grid-area: modif;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+}
+
+.modifiers button {
+  background-color: #ccc;
+}
+
+.modifier:hover {
+  background-color: #c0c0c0;
+}
+
 .digits {
   grid-area: digit;
   display: flex;
@@ -65,6 +68,12 @@ button {
 
 .digits button {
   flex: 1 0 30%;
+
+  background-color: #efefef;
+}
+
+.digit:hover {
+  background-color: #e8e8e8;
 }
 
 .digit.wide {
@@ -72,14 +81,16 @@ button {
   order: 1;
 }
 
-.modifiers {
-  grid-area: modif;
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
+.operators {
+  grid-area: oper;
 }
 
-.operations {
-  grid-area: oper;
+.operators button {
+  background-color: #fca500;
+}
+
+.operator:hover {
+  background-color: #f49e00;
 }
 
 .subgrid {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,7 +71,7 @@ function App() {
     let expressionResult;
 
     try {
-      expressionResult = `${calculateExpression(num1, operator, num2 || num1)}`;
+      expressionResult = `${calculateExpression(num1, operator, num2)}`;
     } catch (error) {
       alert(error.message);
       return;
@@ -130,10 +130,12 @@ function App() {
       return;
     }
 
+    const num1 = Number(prevNumber);
+    const num2 = Number(nextNumber);
     updateExpressionResult({
-      num1: Number(prevNumber),
+      num1,
       operator,
-      num2: Number(nextNumber),
+      num2: nextNumber ? num2 : num1,
     });
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,6 +67,23 @@ function App() {
     }));
   };
 
+  const updateExpressionResult = ({ num1, operator, num2 }) => {
+    let expressionResult;
+
+    try {
+      expressionResult = `${calculateExpression(num1, operator, num2 || num1)}`;
+    } catch (error) {
+      alert(error.message);
+      return;
+    }
+
+    setExpression({
+      prevNumber: expressionResult,
+      operator: '',
+      nextNumber: '',
+    });
+  };
+
   const handleClickAC = () => {
     setExpression({
       prevNumber: '',
@@ -113,25 +130,10 @@ function App() {
       return;
     }
 
-    const num1 = Number(prevNumber);
-    const num2 = Number(nextNumber);
-    let expressionResult;
-
-    try {
-      expressionResult = `${calculateExpression(
-        num1,
-        operator,
-        nextNumber ? num2 : num1
-      )}`;
-    } catch (error) {
-      alert(error.message);
-      return;
-    }
-
-    setExpression({
-      prevNumber: expressionResult,
-      operator: '',
-      nextNumber: '',
+    updateExpressionResult({
+      num1: Number(prevNumber),
+      operator,
+      num2: Number(nextNumber),
     });
   };
 

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Button({ className, handleClick, children: text }) {
+  return (
+    <button className={className} onClick={handleClick}>
+      {text}
+    </button>
+  );
+}
+
+export default Button;

--- a/src/components/CalculationResult.jsx
+++ b/src/components/CalculationResult.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-class CalculationResult extends React.Component {
-  render() {
-    const { prevNumber, operator, nextNumber } = this.props.expression;
-
-    return <h1 id="total">{prevNumber + operator + nextNumber || '0'}</h1>;
-  }
+function CalculationResult({
+  expression: { prevNumber, operator, nextNumber },
+}) {
+  return <h1 id="total">{prevNumber + operator + nextNumber || '0'}</h1>;
 }
 
 export default CalculationResult;

--- a/src/components/CalculatorInputField/AllClear.jsx
+++ b/src/components/CalculatorInputField/AllClear.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 
-class AllClear extends React.Component {
-  render() {
-    return (
-      <div className="modifiers subgrid">
-        <button className="modifier" onClick={this.props.handleClickAC}>
-          AC
-        </button>
-      </div>
-    );
-  }
+function AllClear({ handleClickAC }) {
+  return (
+    <div className="modifiers subgrid">
+      <button className="modifier" onClick={handleClickAC}>
+        AC
+      </button>
+    </div>
+  );
 }
 
 export default AllClear;

--- a/src/components/CalculatorInputField/AllClear.jsx
+++ b/src/components/CalculatorInputField/AllClear.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import Button from '../Button';
 
 function AllClear({ handleClickAC }) {
   return (
     <div className="modifiers subgrid">
-      <button className="modifier" onClick={handleClickAC}>
+      <Button className="modifier" handleClick={handleClickAC}>
         AC
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/CalculatorInputField/Digits.jsx
+++ b/src/components/CalculatorInputField/Digits.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { DIGITS } from '../../constants';
+import Button from '../Button';
 
 function Digits({ handleClickDigit }) {
   return (
     <div className="digits flex">
       {DIGITS.map((digit) => (
-        <button className="digit" key={digit} onClick={handleClickDigit}>
+        <Button className="digit" handleClick={handleClickDigit} key={digit}>
           {digit}
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/src/components/CalculatorInputField/Digits.jsx
+++ b/src/components/CalculatorInputField/Digits.jsx
@@ -1,21 +1,16 @@
 import React from 'react';
+import { DIGITS } from '../../constants';
 
-class Digits extends React.Component {
-  render() {
-    return (
-      <div className="digits flex">
-        {[9, 8, 7, 6, 5, 4, 3, 2, 1, 0].map((digit) => (
-          <button
-            className="digit"
-            key={digit}
-            onClick={this.props.handleClickDigit}
-          >
-            {digit}
-          </button>
-        ))}
-      </div>
-    );
-  }
+function Digits({ handleClickDigit }) {
+  return (
+    <div className="digits flex">
+      {DIGITS.map((digit) => (
+        <button className="digit" key={digit} onClick={handleClickDigit}>
+          {digit}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export default Digits;

--- a/src/components/CalculatorInputField/Operators.jsx
+++ b/src/components/CalculatorInputField/Operators.jsx
@@ -4,10 +4,10 @@ import Button from '../Button';
 
 function Operators({ handleClickOperator }) {
   return (
-    <div className="operations subgrid">
-      {OPERATORS.map((operator) => (
+    <div className="operators subgrid">
+      {Object.values(OPERATORS).map((operator) => (
         <Button
-          className="operation"
+          className="operator"
           handleClick={handleClickOperator}
           key={operator}
         >

--- a/src/components/CalculatorInputField/Operators.jsx
+++ b/src/components/CalculatorInputField/Operators.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { OPERATORS } from '../../constants';
+import Button from '../Button';
 
 function Operators({ handleClickOperator }) {
   return (
     <div className="operations subgrid">
       {OPERATORS.map((operator) => (
-        <button
+        <Button
           className="operation"
+          handleClick={handleClickOperator}
           key={operator}
-          onClick={handleClickOperator}
         >
           {operator}
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/src/components/CalculatorInputField/Operators.jsx
+++ b/src/components/CalculatorInputField/Operators.jsx
@@ -1,21 +1,20 @@
 import React from 'react';
+import { OPERATORS } from '../../constants';
 
-class Operators extends React.Component {
-  render() {
-    return (
-      <div className="operations subgrid">
-        {['/', 'X', '-', '+', '='].map((operator) => (
-          <button
-            className="operation"
-            key={operator}
-            onClick={this.props.handleClickOperator}
-          >
-            {operator}
-          </button>
-        ))}
-      </div>
-    );
-  }
+function Operators({ handleClickOperator }) {
+  return (
+    <div className="operations subgrid">
+      {OPERATORS.map((operator) => (
+        <button
+          className="operation"
+          key={operator}
+          onClick={handleClickOperator}
+        >
+          {operator}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export default Operators;

--- a/src/components/CalculatorInputField/index.jsx
+++ b/src/components/CalculatorInputField/index.jsx
@@ -3,16 +3,18 @@ import Digits from './Digits';
 import AllClear from './AllClear';
 import Operators from './Operators';
 
-class CalculatorInputField extends React.Component {
-  render() {
-    return (
-      <>
-        <AllClear handleClickAC={this.props.handleClickAC} />
-        <Digits handleClickDigit={this.props.handleClickDigit} />
-        <Operators handleClickOperator={this.props.handleClickOperator} />
-      </>
-    );
-  }
+function CalculatorInputField({
+  handleClickAC,
+  handleClickDigit,
+  handleClickOperator,
+}) {
+  return (
+    <>
+      <AllClear handleClickAC={handleClickAC} />
+      <Digits handleClickDigit={handleClickDigit} />
+      <Operators handleClickOperator={handleClickOperator} />
+    </>
+  );
 }
 
 export default CalculatorInputField;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -13,9 +13,21 @@ const INFINITY_CASE_TEXT = '오류';
 
 const LOCAL_STORAGE_EXPRESSION_KEY = 'expression';
 
+const DIGITS = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0];
+
+const OPERATORS = {
+  DIVIDE: '/',
+  MULTIPLY: 'X',
+  MINUS: '-',
+  PLUS: '+',
+  EQUAL: '=',
+};
+
 export {
   MAX_NUMBER_LENGTH,
   ERROR_MESSAGE,
   INFINITY_CASE_TEXT,
   LOCAL_STORAGE_EXPRESSION_KEY,
+  DIGITS,
+  OPERATORS,
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,7 +4,7 @@ const ERROR_MESSAGE = {
   EXCEED_MAX_NUMBER_LENGTH: `${MAX_NUMBER_LENGTH}자리수를 초과하였습니다.`,
   ALLOW_ONE_OPERATOR: '연산자는 하나만 입력할 수 있습니다.',
   STRANGE_OPERATOR(operator) {
-    return `${operator} 연산자는 존재하지 않습니다`;
+    return `'${operator}' 연산자는 존재하지 않습니다`;
   },
   FAIL_TO_GET_DATA: '데이터를 불러오는 데 실패하였습니다.',
 };

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,18 @@
+import { ERROR_MESSAGE, INFINITY_CASE_TEXT, OPERATORS } from '../constants';
+
+const calculateExpression = (num1, operator, num2) => {
+  switch (operator) {
+    case OPERATORS.PLUS:
+      return num1 + num2;
+    case OPERATORS.MINUS:
+      return num1 - num2;
+    case OPERATORS.MULTIPLY:
+      return num1 * num2;
+    case OPERATORS.DIVIDE:
+      return num2 === 0 ? INFINITY_CASE_TEXT : Number.parseInt(num1 / num2);
+    default:
+      throw new Error(ERROR_MESSAGE.STRANGE_OPERATOR(operator));
+  }
+};
+
+export { calculateExpression };


### PR DESCRIPTION
안녕하세요~~

## 데모페이지
[리액트 계산기](https://nan-noo.github.io/react-calculator/)
## 생각
> 리액트는 이전에 써보셨나요? 저는 태태님이 우테코에서 하신 것처럼 vanilla js 로만 개발을 하다가 처음으로 리액트 CRA 로 개발을 했을 때 이렇게 직관적이고 쉽게 UI 를 그릴 수 있다는 게 너무 신기했는데, 태태님은 어떠셨는 지 궁금하네요ㅎㅎ

저는 써보긴 했는데, js공부도 제대로 안 한 상태에서 마구잡이로 쓴 거라ㅎㅎ 이전에 바닐라 js로 구현한 계산기를 react로 다시 하니까 확실히 변화가 느껴지네요. 이벤트 등록도 더 쉽고, 상태 변화 될 때마다 하나하나 업데이트할 필요 없이 자동으로 렌더링 되고.. 편해진 것 같습니다!

step2에서는 useState, useEffect, useCallback 훅을 이용해서 클래스 컴포넌트를 함수형 컴포넌트로 바꿨습니다.
* step1과 비슷하게, state 끌어올리기를 하기 싫어서 App 컴포넌트에서 state를 다루고 있습니다. 그러다보니, App 내용만 커졌는데 분리가 필요할까요?
* 클래스 컴포넌트와는 다르게, useEffect는 state(또는 state를 사용하는 함수)를 내부에서 사용하려 하면 deps 배열에 추가해야 최신 state를 사용할 수 있습니다(빈 배열이면 초기값만 사용 가능). 이번 미션에서 기능을 구현하기 위해 deps에 `handleUnload`함수를 추가하긴 했는데, useCallback을 사용해도 state가 바뀌면 handleUnload도 바뀌니까 결국엔 매 state(expression)이 바뀔 때마다 이벤트를 달고 제거하는 과정이 불필요하게 반복됩니다. **state가 바뀔 때마다 말고, 앱이 시작할 때와 종료될 때 딱 한 번만** 이벤트를 달고 제거하고 싶은데, 다른 방법을 찾지 못했습니다. 아니면 원래 이렇게 구현해야 하나요?
* 그리고 함수가 선언된 위치마다 메모리 할당 시점(?)이 다르다고 해서 state를 사용하지 않는 함수 등은 전역에 선언했습니다. `handleBeforeunload`같은 경우에는 state를 사용하진 않아서 전역에 선언했는데, 내용으론 App 컴포넌트 안에 handle함수가 다 있어서 컴포넌트 안에 넣어야 할 것 같습니다. 어느 위치가 더 적절하다고 생각하시나요?
* 컴포넌트 분리 기준을 일단 UI, 기능, 재사용될 수 있는 요소(공통 컴포넌트!).. 순서로 분리하고 있는데, 어떻게 생각하시나요? 월터님 기준도 궁금합니다!!

감사합니다~~!!