### PR TITLE
[2단계 - 계산기] 시지프(김의진) 미션 제출합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+node_modules

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,105 +1,18 @@
 import './App.css';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import CalculationResult from './components/CalculationResult';
 import CalculatorInputField from './components/CalculatorInputField';
-import {
-  ERROR_MESSAGE,
-  INFINITY_CASE_TEXT,
-  LOCAL_STORAGE_EXPRESSION_KEY,
-  MAX_NUMBER_LENGTH,
-} from './constants';
+import { ERROR_MESSAGE, LOCAL_STORAGE_EXPRESSION_KEY } from './constants';
+import useExpression from './hooks/useExpression';
 
 function App() {
-  const [expression, setExpression] = useState({
-    prevNumber: '',
-    operator: '',
-    nextNumber: '',
-  });
-
-  const handleClickAC = () => {
-    setExpression({
-      prevNumber: '',
-      operator: '',
-      nextNumber: '',
-    });
-  };
-
-  const handleClickDigit = ({ target: { textContent: selectedDigit } }) => {
-    if (expression.prevNumber === INFINITY_CASE_TEXT) {
-      setExpression((prevState) => ({
-        ...prevState,
-        prevNumber: selectedDigit,
-      }));
-      return;
-    }
-
-    updateNumber(
-      expression.operator ? 'nextNumber' : 'prevNumber',
-      selectedDigit
-    );
-  };
-
-  const updateNumber = (numberKey, selectedDigit) => {
-    if (expression[numberKey].length >= MAX_NUMBER_LENGTH) {
-      alert(ERROR_MESSAGE.EXCEED_MAX_NUMBER_LENGTH);
-      return;
-    }
-    setExpression((prevState) => ({
-      ...prevState,
-      [numberKey]: prevState[numberKey] + selectedDigit,
-    }));
-  };
-
-  const handleClickOperator = ({
-    target: { textContent: selectedOperator },
-  }) => {
-    const { prevNumber, operator } = expression;
-
-    if (prevNumber === INFINITY_CASE_TEXT) return;
-
-    if (selectedOperator !== '=' && operator) {
-      alert(ERROR_MESSAGE.ALLOW_ONE_OPERATOR);
-      return;
-    }
-
-    if (selectedOperator !== '=' && !operator) {
-      setExpression((prevState) => ({
-        ...prevState,
-        operator: selectedOperator,
-      }));
-      return;
-    }
-
-    if (operator) {
-      setExpression((prevState) => ({
-        prevNumber: calculateExpression(
-          prevState.prevNumber,
-          prevState.operator,
-          prevState.nextNumber
-        ),
-        operator: '',
-        nextNumber: '',
-      }));
-    }
-  };
-
-  const calculateExpression = (prevNumber, operator, nextNumber) => {
-    const num1 = Number(prevNumber);
-    const num2 = Number(nextNumber);
-
-    switch (operator) {
-      case '+':
-        return num1 + num2;
-      case '-':
-        return num1 - num2;
-      case 'X':
-        return num1 * num2;
-      case '/':
-        return num2 === 0 ? INFINITY_CASE_TEXT : Number.parseInt(num1 / num2);
-      default:
-        alert(ERROR_MESSAGE.STRANGE_OPERATOR(operator));
-    }
-  };
+  const {
+    expression,
+    setExpression,
+    handleClickAC,
+    handleClickDigit,
+    handleClickOperator,
+  } = useExpression();
 
   useEffect(() => {
     window.addEventListener('beforeunload', handleBeforeunload);
@@ -135,7 +48,7 @@ function App() {
   const handleUnload = () => {
     localStorage.setItem(
       LOCAL_STORAGE_EXPRESSION_KEY,
-      JSON.stringify(this.state)
+      JSON.stringify(expression)
     );
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import './App.css';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import CalculationResult from './components/CalculationResult';
 import CalculatorInputField from './components/CalculatorInputField';
 import { ERROR_MESSAGE, LOCAL_STORAGE_EXPRESSION_KEY } from './constants';
@@ -14,11 +14,17 @@ function App() {
     handleClickOperator,
   } = useExpression();
 
+  const expressionRef = useRef(expression);
+
   useEffect(() => {
+    expressionRef.current = expression;
+  }, [expression]);
+
+  useEffect(() => {
+    getLocalStorage();
+
     window.addEventListener('beforeunload', handleBeforeunload);
     window.addEventListener('unload', handleUnload);
-
-    getLocalStorage();
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeunload);
@@ -48,7 +54,7 @@ function App() {
   const handleUnload = () => {
     localStorage.setItem(
       LOCAL_STORAGE_EXPRESSION_KEY,
-      JSON.stringify(expression)
+      JSON.stringify(expressionRef.current)
     );
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
       window.removeEventListener('beforeunload', handleBeforeunload);
       window.removeEventListener('unload', handleUnload);
     };
-  }, []);
+  }, [setExpression]);
 
   const handleBeforeunload = (e) => {
     e.preventDefault();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,10 @@ class App extends React.Component {
     window.addEventListener('beforeunload', this.beforeunload);
     window.addEventListener('unload', this.handleUnload);
 
+    this.getLocalStorage();
+  }
+
+  getLocalStorage() {
     try {
       const expression = JSON.parse(
         localStorage.getItem(LOCAL_STORAGE_EXPRESSION_KEY)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,11 +122,11 @@ class App extends React.Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('beforeunload', this.beforeunload);
+    window.removeEventListener('beforeunload', this.handleBeforeunload);
     window.removeEventListener('unload', this.handleUnload);
   }
 
-  beforeunload = (e) => {
+  handleBeforeunload = (e) => {
     e.preventDefault();
     e.returnValue = '';
   };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,8 +2,9 @@ import './App.css';
 import React, { useEffect, useRef } from 'react';
 import CalculationResult from './components/CalculationResult';
 import CalculatorInputField from './components/CalculatorInputField';
-import { ERROR_MESSAGE, LOCAL_STORAGE_EXPRESSION_KEY } from './constants';
+import { LOCAL_STORAGE_EXPRESSION_KEY } from './constants';
 import useExpression from './hooks/useExpression';
+import { CustomLocalStorage } from './utils/CustomLocalStorage';
 
 function App() {
   const {
@@ -21,7 +22,10 @@ function App() {
   }, [expression]);
 
   useEffect(() => {
-    getLocalStorage();
+    const expression = CustomLocalStorage.load(LOCAL_STORAGE_EXPRESSION_KEY);
+    if (expression) {
+      setExpression(expression);
+    }
 
     window.addEventListener('beforeunload', handleBeforeunload);
     window.addEventListener('unload', handleUnload);
@@ -32,29 +36,15 @@ function App() {
     };
   }, []);
 
-  const getLocalStorage = () => {
-    try {
-      const expression = JSON.parse(
-        localStorage.getItem(LOCAL_STORAGE_EXPRESSION_KEY)
-      );
-      if (!expression) return;
-
-      setExpression(expression);
-    } catch {
-      localStorage.removeItem(LOCAL_STORAGE_EXPRESSION_KEY);
-      alert(ERROR_MESSAGE.FAIL_TO_GET_DATA);
-    }
-  };
-
   const handleBeforeunload = (e) => {
     e.preventDefault();
     e.returnValue = '';
   };
 
   const handleUnload = () => {
-    localStorage.setItem(
+    CustomLocalStorage.save(
       LOCAL_STORAGE_EXPRESSION_KEY,
-      JSON.stringify(expressionRef.current)
+      expressionRef.current
     );
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,6 @@ class App extends React.Component {
   handleClickDigit = ({ target: { textContent: selectedDigit } }) => {
     if (this.state.prevNumber === INFINITY_CASE_TEXT) {
       this.setState({
-        ...this.state,
         prevNumber: selectedDigit,
       });
       return;
@@ -49,13 +48,12 @@ class App extends React.Component {
       return;
     }
     this.setState({
-      ...this.state,
       [numberKey]: this.state[numberKey] + selectedDigit,
     });
   }
 
   handleClickOperator = ({ target: { textContent: selectedOperator } }) => {
-    const { prevNumber, operator, nextNumber } = this.state;
+    const { prevNumber, operator } = this.state;
 
     if (prevNumber === INFINITY_CASE_TEXT) return;
 
@@ -66,18 +64,21 @@ class App extends React.Component {
 
     if (selectedOperator !== '=' && !operator) {
       this.setState({
-        ...this.state,
         operator: selectedOperator,
       });
       return;
     }
 
     if (operator) {
-      this.setState({
-        prevNumber: this.calculateExpression(prevNumber, operator, nextNumber),
+      this.setState((prevState) => ({
+        prevNumber: this.calculateExpression(
+          prevState.prevNumber,
+          prevState.operator,
+          prevState.nextNumber
+        ),
         operator: '',
         nextNumber: '',
-      });
+      }));
     }
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import CalculatorInputField from './components/CalculatorInputField';
 import { LOCAL_STORAGE_EXPRESSION_KEY } from './constants';
 import useExpression from './hooks/useExpression';
 import { CustomLocalStorage } from './utils/CustomLocalStorage';
+import useUnload from './hooks/useUnLoad';
 
 function App() {
   const {
@@ -15,39 +16,18 @@ function App() {
     handleClickOperator,
   } = useExpression();
 
-  const expressionRef = useRef(expression);
-
-  useEffect(() => {
-    expressionRef.current = expression;
-  }, [expression]);
 
   useEffect(() => {
     const expression = CustomLocalStorage.load(LOCAL_STORAGE_EXPRESSION_KEY);
     if (expression) {
       setExpression(expression);
     }
+  }, []);
 
-    window.addEventListener('beforeunload', handleBeforeunload);
-    window.addEventListener('unload', handleUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeunload);
-      window.removeEventListener('unload', handleUnload);
-    };
-  }, [setExpression]);
-
-  const handleBeforeunload = (e) => {
-    e.preventDefault();
-    e.returnValue = '';
-  };
-
-  const handleUnload = () => {
-    CustomLocalStorage.save(
-      LOCAL_STORAGE_EXPRESSION_KEY,
-      expressionRef.current
-    );
-  };
-
+  useUnload(() =>
+    CustomLocalStorage.save(LOCAL_STORAGE_EXPRESSION_KEY, expression)
+  );
+    
   return (
     <div id="app">
       <div className="calculator">

--- a/src/components/CalculationResult.jsx
+++ b/src/components/CalculationResult.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-class CalculationResult extends React.Component {
-  render() {
-    const { prevNumber, operator, nextNumber } = this.props.expression;
+function CalculationResult({ expression }) {
+  const { prevNumber, operator, nextNumber } = expression;
 
-    return <h1 id="total">{prevNumber + operator + nextNumber || '0'}</h1>;
-  }
+  return <h1 id="total">{prevNumber + operator + nextNumber || '0'}</h1>;
 }
 
 export default CalculationResult;

--- a/src/components/CalculatorInputField/AllClear.jsx
+++ b/src/components/CalculatorInputField/AllClear.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 
-class AllClear extends React.Component {
-  render() {
-    return (
-      <div className="modifiers subgrid">
-        <button className="modifier" onClick={this.props.handleClickAC}>
-          AC
-        </button>
-      </div>
-    );
-  }
+function AllClear({ handleClickAC }) {
+  return (
+    <div className="modifiers subgrid">
+      <button className="modifier" onClick={handleClickAC}>
+        AC
+      </button>
+    </div>
+  );
 }
 
 export default AllClear;

--- a/src/components/CalculatorInputField/Digits.jsx
+++ b/src/components/CalculatorInputField/Digits.jsx
@@ -1,23 +1,17 @@
 import React from 'react';
 
-class Digits extends React.Component {
-  render() {
-    return (
-      <div className="digits flex">
-        {Array(10)
-          .fill()
-          .map((_, digit) => (
-            <button
-              className="digit"
-              key={digit}
-              onClick={this.props.handleClickDigit}
-            >
-              {9 - digit}
-            </button>
-          ))}
-      </div>
-    );
-  }
+function Digits({ handleClickDigit }) {
+  return (
+    <div className="digits flex">
+      {Array(10)
+        .fill()
+        .map((_, digit) => (
+          <button className="digit" key={digit} onClick={handleClickDigit}>
+            {9 - digit}
+          </button>
+        ))}
+    </div>
+  );
 }
 
 export default Digits;

--- a/src/components/CalculatorInputField/Digits.jsx
+++ b/src/components/CalculatorInputField/Digits.jsx
@@ -4,15 +4,17 @@ class Digits extends React.Component {
   render() {
     return (
       <div className="digits flex">
-        {[9, 8, 7, 6, 5, 4, 3, 2, 1, 0].map((digit) => (
-          <button
-            className="digit"
-            key={digit}
-            onClick={this.props.handleClickDigit}
-          >
-            {digit}
-          </button>
-        ))}
+        {Array(10)
+          .fill()
+          .map((_, digit) => (
+            <button
+              className="digit"
+              key={digit}
+              onClick={this.props.handleClickDigit}
+            >
+              {9 - digit}
+            </button>
+          ))}
       </div>
     );
   }

--- a/src/components/CalculatorInputField/Operators.jsx
+++ b/src/components/CalculatorInputField/Operators.jsx
@@ -2,22 +2,20 @@ import React from 'react';
 
 const OPERATORS = ['/', 'X', '-', '+', '='];
 
-class Operators extends React.Component {
-  render() {
-    return (
-      <div className="operations subgrid">
-        {OPERATORS.map((operator) => (
-          <button
-            className="operation"
-            key={operator}
-            onClick={this.props.handleClickOperator}
-          >
-            {operator}
-          </button>
-        ))}
-      </div>
-    );
-  }
+function Operators({ handleClickOperator }) {
+  return (
+    <div className="operations subgrid">
+      {OPERATORS.map((operator) => (
+        <button
+          className="operation"
+          key={operator}
+          onClick={handleClickOperator}
+        >
+          {operator}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export default Operators;

--- a/src/components/CalculatorInputField/Operators.jsx
+++ b/src/components/CalculatorInputField/Operators.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
+const OPERATORS = ['/', 'X', '-', '+', '='];
+
 class Operators extends React.Component {
   render() {
     return (
       <div className="operations subgrid">
-        {['/', 'X', '-', '+', '='].map((operator) => (
+        {OPERATORS.map((operator) => (
           <button
             className="operation"
             key={operator}

--- a/src/components/CalculatorInputField/index.jsx
+++ b/src/components/CalculatorInputField/index.jsx
@@ -3,16 +3,18 @@ import Digits from './Digits';
 import AllClear from './AllClear';
 import Operators from './Operators';
 
-class CalculatorInputField extends React.Component {
-  render() {
-    return (
-      <>
-        <AllClear handleClickAC={this.props.handleClickAC} />
-        <Digits handleClickDigit={this.props.handleClickDigit} />
-        <Operators handleClickOperator={this.props.handleClickOperator} />
-      </>
-    );
-  }
+function CalculatorInputField({
+  handleClickAC,
+  handleClickDigit,
+  handleClickOperator,
+}) {
+  return (
+    <>
+      <AllClear handleClickAC={handleClickAC} />
+      <Digits handleClickDigit={handleClickDigit} />
+      <Operators handleClickOperator={handleClickOperator} />
+    </>
+  );
 }
 
 export default CalculatorInputField;

--- a/src/hooks/useExpression.js
+++ b/src/hooks/useExpression.js
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import {
+  ERROR_MESSAGE,
+  INFINITY_CASE_TEXT,
+  MAX_NUMBER_LENGTH,
+} from '../constants';
+
+const calculateExpression = (prevNumber, operator, nextNumber) => {
+  const num1 = Number(prevNumber);
+  const num2 = Number(nextNumber);
+
+  switch (operator) {
+    case '+':
+      return num1 + num2;
+    case '-':
+      return num1 - num2;
+    case 'X':
+      return num1 * num2;
+    case '/':
+      return num2 === 0 ? INFINITY_CASE_TEXT : Number.parseInt(num1 / num2);
+    default:
+      alert(ERROR_MESSAGE.STRANGE_OPERATOR(operator));
+  }
+};
+
+export default function useExpression() {
+  const [expression, setExpression] = useState({
+    prevNumber: '',
+    operator: '',
+    nextNumber: '',
+  });
+
+  const handleClickAC = () => {
+    setExpression({
+      prevNumber: '',
+      operator: '',
+      nextNumber: '',
+    });
+  };
+
+  const handleClickDigit = ({ target: { textContent: selectedDigit } }) => {
+    if (expression.prevNumber === INFINITY_CASE_TEXT) {
+      setExpression((prevState) => ({
+        ...prevState,
+        prevNumber: selectedDigit,
+      }));
+      return;
+    }
+
+    updateNumber(
+      expression.operator ? 'nextNumber' : 'prevNumber',
+      selectedDigit
+    );
+  };
+
+  const updateNumber = (numberKey, selectedDigit) => {
+    if (expression[numberKey].length >= MAX_NUMBER_LENGTH) {
+      alert(ERROR_MESSAGE.EXCEED_MAX_NUMBER_LENGTH);
+      return;
+    }
+    setExpression((prevState) => ({
+      ...prevState,
+      [numberKey]: prevState[numberKey] + selectedDigit,
+    }));
+  };
+
+  const handleClickOperator = ({
+    target: { textContent: selectedOperator },
+  }) => {
+    const { prevNumber, operator } = expression;
+
+    if (prevNumber === INFINITY_CASE_TEXT) return;
+
+    if (selectedOperator !== '=' && operator) {
+      alert(ERROR_MESSAGE.ALLOW_ONE_OPERATOR);
+      return;
+    }
+
+    if (selectedOperator !== '=' && !operator) {
+      setExpression((prevState) => ({
+        ...prevState,
+        operator: selectedOperator,
+      }));
+      return;
+    }
+
+    if (operator) {
+      setExpression((prevState) => ({
+        prevNumber: calculateExpression(
+          prevState.prevNumber,
+          prevState.operator,
+          prevState.nextNumber
+        ),
+        operator: '',
+        nextNumber: '',
+      }));
+    }
+  };
+
+  return {
+    expression,
+    setExpression,
+    handleClickAC,
+    handleClickDigit,
+    handleClickOperator,
+  };
+}

--- a/src/hooks/useExpression.js
+++ b/src/hooks/useExpression.js
@@ -23,19 +23,17 @@ const calculateExpression = (prevNumber, operator, nextNumber) => {
   }
 };
 
+const initialExpression = {
+  prevNumber: '',
+  operator: '',
+  nextNumber: '',
+};
+
 export default function useExpression() {
-  const [expression, setExpression] = useState({
-    prevNumber: '',
-    operator: '',
-    nextNumber: '',
-  });
+  const [expression, setExpression] = useState(initialExpression);
 
   const handleClickAC = () => {
-    setExpression({
-      prevNumber: '',
-      operator: '',
-      nextNumber: '',
-    });
+    setExpression(initialExpression);
   };
 
   const handleClickDigit = ({ target: { textContent: selectedDigit } }) => {
@@ -71,30 +69,43 @@ export default function useExpression() {
 
     if (prevNumber === INFINITY_CASE_TEXT) return;
 
-    if (selectedOperator !== '=' && operator) {
-      alert(ERROR_MESSAGE.ALLOW_ONE_OPERATOR);
-      return;
-    }
+    const pattern = {
+      equal_calculate: {
+        case: selectedOperator === '=' && operator,
+        func() {
+          setExpression((prevState) => ({
+            ...initialExpression,
+            prevNumber: calculateExpression(
+              prevState.prevNumber,
+              prevState.operator,
+              prevState.nextNumber
+            ),
+          }));
+        },
+      },
+      add_operator: {
+        case: selectedOperator !== '=' && !operator,
+        func() {
+          setExpression((prevState) => ({
+            ...prevState,
+            operator: selectedOperator,
+          }));
+        },
+      },
+      over_two_operator: {
+        case: selectedOperator !== '=' && operator,
+        func() {
+          alert(ERROR_MESSAGE.ALLOW_ONE_OPERATOR);
+        },
+      },
+      other: {
+        case: true,
+        func() {},
+      },
+    };
 
-    if (selectedOperator !== '=' && !operator) {
-      setExpression((prevState) => ({
-        ...prevState,
-        operator: selectedOperator,
-      }));
-      return;
-    }
-
-    if (operator) {
-      setExpression((prevState) => ({
-        prevNumber: calculateExpression(
-          prevState.prevNumber,
-          prevState.operator,
-          prevState.nextNumber
-        ),
-        operator: '',
-        nextNumber: '',
-      }));
-    }
+    const currentCase = Object.keys(pattern).find((key) => pattern[key].case);
+    pattern[currentCase].func();
   };
 
   return {

--- a/src/hooks/useUnload.jsx
+++ b/src/hooks/useUnload.jsx
@@ -1,0 +1,19 @@
+import { useRef, useEffect } from 'react';
+
+const useUnload = (fn) => {
+  const cb = useRef(fn);
+
+  useEffect(() => {
+    cb.current = fn;
+  }, [fn]);
+
+  useEffect(() => {
+    const onUnload = (...args) => cb.current?.(...args);
+
+    window.addEventListener('beforeunload', onUnload);
+
+    return () => window.removeEventListener('beforeunload', onUnload);
+  }, []);
+};
+
+export default useUnload;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import "./index.css";
-import App from "./App";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <App />

--- a/src/utils/CustomLocalStorage.js
+++ b/src/utils/CustomLocalStorage.js
@@ -1,0 +1,15 @@
+import { ERROR_MESSAGE } from '../constants';
+
+export const CustomLocalStorage = {
+  load(key) {
+    try {
+      return JSON.parse(localStorage.getItem(key));
+    } catch {
+      localStorage.removeItem(key);
+      alert(ERROR_MESSAGE.FAIL_TO_GET_DATA);
+    }
+  },
+  save(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+};


### PR DESCRIPTION
리트님 안녕하세요! 
class component를 functional component 로 migration했습니다.

## [데모페이지](https://euijinkk.github.io/react-calculator/)

## 주안점

- custom hook 분리
  계산기 상태인 expression 관련 로직을 custom hook으로 분리하였습니다. 로직이 많아서 App.js가 비대해져서 분리를 시도해보았습니다. custom hook을 많이 써본적이 없어서, 분리 기준이 명확하지 않아, 다양하게 시도해보고 있습니다.

- 왜 unload의 eventListener는 이벤트가 부착되는 시점의 state를 기억할까요?
  unload가 발생할 때 handleUnload를 실행하라고 하면, unload 시점의 expression을 참조한다고 생각하는데, 부착 시점의 expression을 기억합니다. 혹시 왜 이럴까요?

```javascript
useEffect(() => {
    window.addEventListener('unload', handleUnload);
  }, []);

  const handleUnload = () => {
    CustomLocalStorage.save(
      LOCAL_STORAGE_EXPRESSION_KEY,
      expression
    );
  };
```

- unMount시에 상태 기억하기
```javascript
useEffect(() => {
    window.addEventListener('unload', handleUnload);

    return () => {
      window.removeEventListener('unload', handleUnload);
    }
  }, []);

  const handleUnload = () => {
    CustomLocalStorage.save(
      LOCAL_STORAGE_EXPRESSION_KEY,
      expression
    );
  };
```

위 방식으로 하면, expression 상태 초기값을 참조하게 됩니다. 

```javascript
useEffect(() => {
    window.addEventListener('unload', handleUnload);

    return () => {
      window.removeEventListener('unload', handleUnload);
    }
  }, [handleUnload]);
```

그래서 handleUnload를 dependency로 추가하면, 매번 참조값이 변경되기 때문에, unMount시에 적절한 값을 참조할 수 있게 됩니다. 하지만 이 과정에서 매번 event가 add/remove 됩니다. 이것이 비용이 크다고 생각하여, Ref를 사용했습니다. Ref 변수 하나를 선언하여, expression이 바뀔 떄마다 Ref를 변경시켜주었습니다. 그런데 찾아보니 useEffect event Listener 가 매우 빠르다는 [의견](https://github.com/facebook/react/issues/14699#issuecomment-457653146)이 있어서 혼란스럽네요. 

```javascript
const expressionRef = useRef(expression);

useEffect(() => {
  expressionRef.current = expression;
}, [expression]);

useEffect(() => {
    window.addEventListener('unload', handleUnload);

    return () => {
      window.removeEventListener('unload', handleUnload);
    }
  }, []);
```

- clean-up 에서 Ref 참조가 왜 안될까요?
왜 인지 모르겠는데, 아래 방식처럼 clean-up 에서 Ref값도 잘 참조하지 못 하더군요. 이번에도 초기값을 참조합니다. useEffect는 내부에서 함수를 참조하게 있는 것이 아니라, 값 자체를 기억하고 있는 것일까요?...

[검색하면](https://www.timveletta.com/blog/2020-07-14-accessing-react-state-in-your-component-cleanup-with-hooks/) 이 해결책이 나오는데 말이죠.. 그래서 일단 Unload 이벤트를 다는 방식으로 해결했습니다. 왜 안될까요? 

```javascript
useEffect(() => {
    return () => {
      CustomLocalStorage.save(
        LOCAL_STORAGE_EXPRESSION_KEY,
        expressionRef.current
      );
    }
  }, []);
```

- 2가지 boolean 값을 조합하면 4가지 case가 나옵니다. 이때, if문으로 하는 경우 if 문을 중첩으로 사용하는 등 if문 3개를 써야해서 가독성이 좋지 않더군요. 그래서 pattern matching과 유사하게 [시도해보았습니다](https://github.com/woowacourse/react-calculator/commit/752c65d4179909bbf653917f9a54bbff3ff73801) 
리트님은 많은 케이스를 다루는 경우,(switch를 사용할 수 없을때) 어떻게 해결하시는지 궁금합니다!
