### PR TITLE
[2단계 - 계산기] 마르코(장원석) 미션 제출합니다.

### DIFF
--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -6,6 +6,7 @@ import Modifier from './components/Modifier';
 import Operation from './components/Operation';
 import Result from './components/Result';
 import calculateResult from './utils/calculateResult';
+import { load, save } from './utils/storage';
 
 const DEFAULT_VALUE = { operand: ['0', ''], operator: '', index: 0 };
 
@@ -22,11 +23,12 @@ function Calculator() {
   };
 
   const handleUnload = () => {
-    localStorage.setItem('state', JSON.stringify(input));
+    save('calculator', input);
   };
 
   useEffect(() => {
-    const localState = JSON.parse(localStorage.getItem('state'));
+    const localState = load('calculator');
+
     if (localState) {
       setInput({
         operator: localState.operator,

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable class-methods-use-this */
 import React, { Component } from 'react';
 
 export default class Calculator extends Component {
@@ -9,11 +11,6 @@ export default class Calculator extends Component {
       operator: '',
       index: 0,
     };
-
-    window.addEventListener('beforeunload', e => {
-      e.preventDefault();
-      e.returnValue = '';
-    });
   }
 
   componentDidMount() {
@@ -24,10 +21,21 @@ export default class Calculator extends Component {
       this.setState({ operator: localState.operator });
       this.setState({ index: localState.index });
     }
+
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   componentDidUpdate() {
     localStorage.setItem('state', JSON.stringify(this.state));
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
+  }
+
+  handleBeforeUnload(event) {
+    event.preventDefault();
+    event.returnValue = '';
   }
 
   handleClickDigit(digit) {

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -23,20 +23,22 @@ export default class Calculator extends Component {
     }
 
     window.addEventListener('beforeunload', this.handleBeforeUnload);
-  }
-
-  componentDidUpdate() {
-    localStorage.setItem('state', JSON.stringify(this.state));
+    window.addEventListener('unload', this.handleUnload);
   }
 
   componentWillUnmount() {
     window.removeEventListener('beforeunload', this.handleBeforeUnload);
+    window.removeEventListener('unload', this.handleUnload);
   }
 
   handleBeforeUnload(event) {
     event.preventDefault();
     event.returnValue = '';
   }
+
+  handleUnload = () => {
+    localStorage.setItem('state', JSON.stringify(this.state));
+  };
 
   handleClickDigit(digit) {
     if (this.state.operand[0] === '오류') {

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -2,6 +2,20 @@
 /* eslint-disable class-methods-use-this */
 import React, { Component } from 'react';
 
+function calculateResult(operand, operator) {
+  switch (operator) {
+    case '+':
+      return +operand[0] + +operand[1];
+    case '-':
+      return +operand[0] - +operand[1];
+    case 'X':
+      return +operand[0] * +operand[1];
+    case '/':
+      return Math.floor(+operand[0] / +operand[1]);
+    default:
+      return '오류';
+  }
+}
 export default class Calculator extends Component {
   constructor() {
     super();
@@ -22,8 +36,6 @@ export default class Calculator extends Component {
         operator: localState.operator,
         index: localState.index,
       });
-      // this.setState({ operator: localState.operator });
-      // this.setState({ index: localState.index });
     }
 
     window.addEventListener('beforeunload', this.handleBeforeUnload);
@@ -106,23 +118,8 @@ export default class Calculator extends Component {
     if (!this.state.operator) {
       return;
     }
-    let result = null;
-    switch (operator) {
-      case '+':
-        result = +operand[0] + +operand[1];
-        break;
-      case '-':
-        result = +operand[0] - +operand[1];
-        break;
-      case 'X':
-        result = +operand[0] * +operand[1];
-        break;
-      case '/':
-        result = Math.floor(+operand[0] / +operand[1]);
-        break;
-      default:
-        break;
-    }
+
+    const result = calculateResult(operand, operator);
 
     if (result === Infinity) {
       this.setState({

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -1,6 +1,10 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable class-methods-use-this */
 import React, { Component } from 'react';
+import Digit from './components/Digit';
+import Modifier from './components/Modifier';
+import Operation from './components/Operation';
+import Result from './components/Result';
 
 function calculateResult(operand, operator) {
   switch (operator) {
@@ -47,16 +51,16 @@ export default class Calculator extends Component {
     window.removeEventListener('unload', this.handleUnload);
   }
 
-  handleBeforeUnload(event) {
+  handleBeforeUnload = event => {
     event.preventDefault();
     event.returnValue = '';
-  }
+  };
 
   handleUnload = () => {
     localStorage.setItem('state', JSON.stringify(this.state));
   };
 
-  handleClickDigit(digit) {
+  handleClickDigit = digit => {
     if (this.state.operand[0] === '오류') {
       alert('오류입니다. AC를 눌러 값을 초기화해주세요.');
       return;
@@ -83,9 +87,9 @@ export default class Calculator extends Component {
       default:
         break;
     }
-  }
+  };
 
-  handleClickOperation(operator) {
+  handleClickOperation = operator => {
     if (this.state.operand[0] === '오류') {
       alert('오류입니다. AC를 눌러 값을 초기화해주세요.');
       return;
@@ -104,17 +108,17 @@ export default class Calculator extends Component {
       operator,
       index: 1,
     });
-  }
+  };
 
-  handleClickModifier() {
+  handleClickModifier = () => {
     this.setState({
       operand: ['0', ''],
       operator: '',
       index: 0,
     });
-  }
+  };
 
-  calculate(operand, operator) {
+  calculate = (operand, operator) => {
     if (!this.state.operator) {
       return;
     }
@@ -135,71 +139,24 @@ export default class Calculator extends Component {
       operator: '',
       index: 0,
     });
-  }
-
-  renderDigit(i) {
-    return (
-      <button className="digit" type="button" onClick={this.handleClickDigit.bind(this, i)}>
-        {i}
-      </button>
-    );
-  }
-
-  renderModifier() {
-    return (
-      <button type="button" className="modifier" onClick={this.handleClickModifier.bind(this)}>
-        AC
-      </button>
-    );
-  }
-
-  renderResult() {
-    return (
-      <h1 id="total">
-        {this.state.operand[0]}
-        {this.state.operator}
-        {this.state.operand[1]}
-      </h1>
-    );
-  }
-
-  renderOperation(operation) {
-    return (
-      <button
-        type="button"
-        className="operation"
-        onClick={this.handleClickOperation.bind(this, operation)}
-      >
-        {operation}
-      </button>
-    );
-  }
+  };
 
   render() {
-    console.log(this.state);
-
     return (
       <div className="calculator">
-        {this.renderResult()}
+        <Result operator={this.state.operator} operand={this.state.operand} />
         <div className="digits flex">
-          {this.renderDigit('9')}
-          {this.renderDigit('8')}
-          {this.renderDigit('7')}
-          {this.renderDigit('6')}
-          {this.renderDigit('5')}
-          {this.renderDigit('4')}
-          {this.renderDigit('3')}
-          {this.renderDigit('2')}
-          {this.renderDigit('1')}
-          {this.renderDigit('0')}
+          {[9, 8, 7, 6, 5, 4, 3, 2, 1, 0].map(digit => (
+            <Digit key={digit} digit={String(digit)} onClick={this.handleClickDigit} />
+          ))}
         </div>
-        <div className="modifiers subgrid">{this.renderModifier()}</div>
+        <div className="modifiers subgrid">
+          <Modifier onClick={this.handleClickModifier} />
+        </div>
         <div className="operations subgrid">
-          {this.renderOperation('/')}
-          {this.renderOperation('X')}
-          {this.renderOperation('-')}
-          {this.renderOperation('+')}
-          {this.renderOperation('=')}
+          {['/', 'X', '-', '+', '='].map(operator => (
+            <Operation key={operator} operator={operator} onClick={this.handleClickOperation} />
+          ))}
         </div>
       </div>
     );

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -139,15 +139,19 @@ function Calculator() {
       <Result operator={input.operator} operand={input.operand} />
       <div className="digits flex">
         {[9, 8, 7, 6, 5, 4, 3, 2, 1, 0].map(digit => (
-          <Digit key={digit} digit={String(digit)} onClick={handleClickDigit} />
+          <Digit key={digit} digit={String(digit)} onClick={handleClickDigit}>
+            {digit}
+          </Digit>
         ))}
       </div>
       <div className="modifiers subgrid">
-        <Modifier onClick={handleClickModifier} />
+        <Modifier onClick={handleClickModifier}>AC</Modifier>
       </div>
       <div className="operations subgrid">
         {['/', 'X', '-', '+', '='].map(operatorValue => (
-          <Operation key={operatorValue} operator={operatorValue} onClick={handleClickOperation} />
+          <Operation key={operatorValue} operator={operatorValue} onClick={handleClickOperation}>
+            {operatorValue}
+          </Operation>
         ))}
       </div>
     </div>

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -1,87 +1,67 @@
 /* eslint-disable no-param-reassign */
-/* eslint-disable class-methods-use-this */
-import React, { Component } from 'react';
+
+import React, { useState, useEffect } from 'react';
 import Digit from './components/Digit';
 import Modifier from './components/Modifier';
 import Operation from './components/Operation';
 import Result from './components/Result';
+import calculateResult from './utils/calculateResult';
 
-function calculateResult(operand, operator) {
-  switch (operator) {
-    case '+':
-      return +operand[0] + +operand[1];
-    case '-':
-      return +operand[0] - +operand[1];
-    case 'X':
-      return +operand[0] * +operand[1];
-    case '/':
-      return Math.floor(+operand[0] / +operand[1]);
-    default:
-      return '오류';
-  }
-}
-export default class Calculator extends Component {
-  constructor() {
-    super();
+function Calculator() {
+  const [operand, setOperand] = useState(['0', '']);
+  const [operator, setOperator] = useState('');
+  const [index, setIndex] = useState(0);
 
-    this.state = {
-      operand: ['0', ''],
-      operator: '',
-      index: 0,
-    };
-  }
-
-  componentDidMount() {
-    const localState = JSON.parse(localStorage.getItem('state'));
-
-    if (localState) {
-      this.setState({
-        operand: localState.operand,
-        operator: localState.operator,
-        index: localState.index,
-      });
-    }
-
-    window.addEventListener('beforeunload', this.handleBeforeUnload);
-    window.addEventListener('unload', this.handleUnload);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('beforeunload', this.handleBeforeUnload);
-    window.removeEventListener('unload', this.handleUnload);
-  }
-
-  handleBeforeUnload = event => {
+  const handleBeforeUnload = event => {
     event.preventDefault();
     event.returnValue = '';
   };
 
-  handleUnload = () => {
-    localStorage.setItem('state', JSON.stringify(this.state));
+  const handleUnload = () => {
+    const state = { operand, operator, index };
+    localStorage.setItem('state', JSON.stringify(state));
   };
 
-  handleClickDigit = digit => {
-    if (this.state.operand[0] === '오류') {
+  useEffect(() => {
+    const localState = JSON.parse(localStorage.getItem('state'));
+    if (localState) {
+      setOperator(localState.operator);
+      setIndex(localState.index);
+      setOperand(localState.operand);
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('unload', handleUnload);
+    return () => {
+      window.removeEventListener('unload', handleUnload);
+    };
+  }, [handleUnload]);
+
+  const handleClickDigit = digit => {
+    if (operand[0] === '오류') {
       alert('오류입니다. AC를 눌러 값을 초기화해주세요.');
       return;
     }
 
-    if (+(this.state.operand[this.state.index] + digit) >= 1000) {
+    if (+(operand[index] + digit) >= 1000) {
       alert('숫자는 한번에 최대 3자리 수까지 입력 가능합니다.');
       return;
     }
 
-    switch (this.state.index) {
+    switch (index) {
       case 0:
-        this.setState(prevState => ({
-          operand: [String(+(prevState.operand[0] + digit)), ''],
-        }));
+        setOperand(prevOperand => [String(+(prevOperand[0] + digit)), '']);
         break;
 
       case 1:
-        this.setState(prevState => ({
-          operand: [String(+prevState.operand[0]), String(+(prevState.operand[1] + digit))],
-        }));
+        setOperand(prevOperand => [String(+prevOperand[0]), String(+(prevOperand[1] + digit))]);
         break;
 
       default:
@@ -89,76 +69,68 @@ export default class Calculator extends Component {
     }
   };
 
-  handleClickOperation = operator => {
-    if (this.state.operand[0] === '오류') {
+  const calculate = (operandFactor, operatorFactor) => {
+    if (!operatorFactor) {
+      return;
+    }
+
+    const result = calculateResult(operandFactor, operatorFactor);
+
+    if (result === Infinity) {
+      setOperator('');
+      setOperand(['오류', '']);
+
+      return;
+    }
+
+    setOperand([String(result), '']);
+    setOperator('');
+    setIndex(0);
+  };
+
+  const handleClickOperation = operatorFactor => {
+    if (operand[0] === '오류') {
       alert('오류입니다. AC를 눌러 값을 초기화해주세요.');
       return;
     }
 
-    if (operator === '=') {
-      this.calculate(this.state.operand, this.state.operator);
+    if (operatorFactor === '=') {
+      calculate(operand, operator);
       return;
     }
 
-    if (this.state.operator) {
+    if (operator) {
       return;
     }
 
-    this.setState({
-      operator,
-      index: 1,
-    });
+    setOperator(operatorFactor);
+    setIndex(1);
   };
 
-  handleClickModifier = () => {
-    this.setState({
-      operand: ['0', ''],
-      operator: '',
-      index: 0,
-    });
+  const handleClickModifier = () => {
+    setOperand(['0', '']);
+    setOperator('');
+    setIndex(0);
   };
 
-  calculate = (operand, operator) => {
-    if (!this.state.operator) {
-      return;
-    }
-
-    const result = calculateResult(operand, operator);
-
-    if (result === Infinity) {
-      this.setState({
-        operand: ['오류', ''],
-        operator: '',
-      });
-
-      return;
-    }
-
-    this.setState({
-      operand: [String(result), ''],
-      operator: '',
-      index: 0,
-    });
-  };
-
-  render() {
-    return (
-      <div className="calculator">
-        <Result operator={this.state.operator} operand={this.state.operand} />
-        <div className="digits flex">
-          {[9, 8, 7, 6, 5, 4, 3, 2, 1, 0].map(digit => (
-            <Digit key={digit} digit={String(digit)} onClick={this.handleClickDigit} />
-          ))}
-        </div>
-        <div className="modifiers subgrid">
-          <Modifier onClick={this.handleClickModifier} />
-        </div>
-        <div className="operations subgrid">
-          {['/', 'X', '-', '+', '='].map(operator => (
-            <Operation key={operator} operator={operator} onClick={this.handleClickOperation} />
-          ))}
-        </div>
+  return (
+    <div className="calculator">
+      <Result operator={operator} operand={operand} />
+      <div className="digits flex">
+        {[9, 8, 7, 6, 5, 4, 3, 2, 1, 0].map(digit => (
+          <Digit key={digit} digit={String(digit)} onClick={handleClickDigit} />
+        ))}
       </div>
-    );
-  }
+      <div className="modifiers subgrid">
+        <Modifier onClick={handleClickModifier} />
+      </div>
+      <div className="operations subgrid">
+        {['/', 'X', '-', '+', '='].map(operatorValue => (
+          <Operation key={operatorValue} operator={operatorValue} onClick={handleClickOperation} />
+        ))}
+      </div>
+    </div>
+  );
 }
+
+export default Calculator;

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Digit from './components/Digit';
 import Modifier from './components/Modifier';
 import Operation from './components/Operation';
@@ -22,8 +22,14 @@ function Calculator() {
     event.returnValue = '';
   };
 
+  const storedInput = useRef(input);
+
+  useEffect(() => {
+    storedInput.current = input;
+  }, [input]);
+
   const handleUnload = () => {
-    save('calculator', input);
+    save('calculator', storedInput.current);
   };
 
   useEffect(() => {
@@ -38,18 +44,13 @@ function Calculator() {
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('unload', handleUnload);
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('unload', handleUnload);
-    return () => {
       window.removeEventListener('unload', handleUnload);
     };
-  }, [handleUnload]);
+  }, []);
 
   const handleClickDigit = digit => {
     if (input.operand[0] === '오류') {

--- a/src/Calculator.jsx
+++ b/src/Calculator.jsx
@@ -17,9 +17,13 @@ export default class Calculator extends Component {
     const localState = JSON.parse(localStorage.getItem('state'));
 
     if (localState) {
-      this.setState({ operand: localState.operand });
-      this.setState({ operator: localState.operator });
-      this.setState({ index: localState.index });
+      this.setState({
+        operand: localState.operand,
+        operator: localState.operator,
+        index: localState.index,
+      });
+      // this.setState({ operator: localState.operator });
+      // this.setState({ index: localState.index });
     }
 
     window.addEventListener('beforeunload', this.handleBeforeUnload);
@@ -84,14 +88,18 @@ export default class Calculator extends Component {
       return;
     }
 
-    this.setState({ operator });
-    this.setState({ index: 1 });
+    this.setState({
+      operator,
+      index: 1,
+    });
   }
 
   handleClickModifier() {
-    this.setState({ operand: ['0', ''] });
-    this.setState({ operator: '' });
-    this.setState({ index: 0 });
+    this.setState({
+      operand: ['0', ''],
+      operator: '',
+      index: 0,
+    });
   }
 
   calculate(operand, operator) {
@@ -117,14 +125,19 @@ export default class Calculator extends Component {
     }
 
     if (result === Infinity) {
-      this.setState({ operand: ['오류', ''] });
-      this.setState({ operator: '' });
+      this.setState({
+        operand: ['오류', ''],
+        operator: '',
+      });
+
       return;
     }
 
-    this.setState({ operand: [String(result), ''] });
-    this.setState({ operator: '' });
-    this.setState({ index: 0 });
+    this.setState({
+      operand: [String(result), ''],
+      operator: '',
+      index: 0,
+    });
   }
 
   renderDigit(i) {
@@ -166,6 +179,8 @@ export default class Calculator extends Component {
   }
 
   render() {
+    console.log(this.state);
+
     return (
       <div className="calculator">
         {this.renderResult()}

--- a/src/components/Digit.jsx
+++ b/src/components/Digit.jsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+
+export default class Digit extends Component {
+  render() {
+    const { digit } = this.props;
+    const { onClick } = this.props;
+
+    return (
+      <button
+        className="digit"
+        type="button"
+        onClick={() => {
+          onClick(digit);
+        }}
+      >
+        {digit}
+      </button>
+    );
+  }
+}

--- a/src/components/Digit.jsx
+++ b/src/components/Digit.jsx
@@ -1,20 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Digit extends Component {
-  render() {
-    const { digit } = this.props;
-    const { onClick } = this.props;
-
-    return (
-      <button
-        className="digit"
-        type="button"
-        onClick={() => {
-          onClick(digit);
-        }}
-      >
-        {digit}
-      </button>
-    );
-  }
+function Digit(props) {
+  return (
+    <button
+      className="digit"
+      type="button"
+      onClick={() => {
+        props.onClick(props.digit);
+      }}
+    >
+      {props.digit}
+    </button>
+  );
 }
+
+export default Digit;

--- a/src/components/Digit.jsx
+++ b/src/components/Digit.jsx
@@ -9,7 +9,7 @@ function Digit(props) {
         props.onClick(props.digit);
       }}
     >
-      {props.digit}
+      {props.children}
     </button>
   );
 }

--- a/src/components/Modifier.jsx
+++ b/src/components/Modifier.jsx
@@ -1,13 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Modifier extends Component {
-  render() {
-    const { onClick } = this.props;
-
-    return (
-      <button type="button" className="modifier" onClick={onClick}>
-        AC
-      </button>
-    );
-  }
+function Modifier(props) {
+  return (
+    <button type="button" className="modifier" onClick={props.onClick}>
+      AC
+    </button>
+  );
 }
+
+export default Modifier;

--- a/src/components/Modifier.jsx
+++ b/src/components/Modifier.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 function Modifier(props) {
   return (
     <button type="button" className="modifier" onClick={props.onClick}>
-      AC
+      {props.children}
     </button>
   );
 }

--- a/src/components/Modifier.jsx
+++ b/src/components/Modifier.jsx
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+
+export default class Modifier extends Component {
+  render() {
+    const { onClick } = this.props;
+
+    return (
+      <button type="button" className="modifier" onClick={onClick}>
+        AC
+      </button>
+    );
+  }
+}

--- a/src/components/Operation.jsx
+++ b/src/components/Operation.jsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+
+export default class Operation extends Component {
+  render() {
+    const { operator } = this.props;
+    const { onClick } = this.props;
+
+    return (
+      <button
+        type="button"
+        className="operation"
+        onClick={() => {
+          onClick(operator);
+        }}
+      >
+        {operator}
+      </button>
+    );
+  }
+}

--- a/src/components/Operation.jsx
+++ b/src/components/Operation.jsx
@@ -1,20 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Operation extends Component {
-  render() {
-    const { operator } = this.props;
-    const { onClick } = this.props;
-
-    return (
-      <button
-        type="button"
-        className="operation"
-        onClick={() => {
-          onClick(operator);
-        }}
-      >
-        {operator}
-      </button>
-    );
-  }
+function Operation(props) {
+  return (
+    <button
+      type="button"
+      className="operation"
+      onClick={() => {
+        props.onClick(props.operator);
+      }}
+    >
+      {props.operator}
+    </button>
+  );
 }
+
+export default Operation;

--- a/src/components/Operation.jsx
+++ b/src/components/Operation.jsx
@@ -9,7 +9,7 @@ function Operation(props) {
         props.onClick(props.operator);
       }}
     >
-      {props.operator}
+      {props.children}
     </button>
   );
 }

--- a/src/components/Result.jsx
+++ b/src/components/Result.jsx
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+
+export default class Result extends Component {
+  render() {
+    return (
+      <h1 id="total">
+        {this.props.operand[0]}
+        {this.props.operator}
+        {this.props.operand[1]}
+      </h1>
+    );
+  }
+}

--- a/src/components/Result.jsx
+++ b/src/components/Result.jsx
@@ -1,13 +1,13 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Result extends Component {
-  render() {
-    return (
-      <h1 id="total">
-        {this.props.operand[0]}
-        {this.props.operator}
-        {this.props.operand[1]}
-      </h1>
-    );
-  }
+function Result(props) {
+  return (
+    <h1 id="total">
+      {props.operand[0]}
+      {props.operator}
+      {props.operand[1]}
+    </h1>
+  );
 }
+
+export default Result;

--- a/src/utils/calculateResult.js
+++ b/src/utils/calculateResult.js
@@ -1,0 +1,16 @@
+function calculateResult(operand, operator) {
+  switch (operator) {
+    case '+':
+      return +operand[0] + +operand[1];
+    case '-':
+      return +operand[0] - +operand[1];
+    case 'X':
+      return +operand[0] * +operand[1];
+    case '/':
+      return Math.floor(+operand[0] / +operand[1]);
+    default:
+      return '오류';
+  }
+}
+
+export default calculateResult;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,3 @@
+export const save = (key, input) => localStorage.setItem(key, JSON.stringify(input));
+
+export const load = key => JSON.parse(localStorage.getItem(key));


### PR DESCRIPTION
## [데모페이지](https://wonsss.github.io/react-calculator/)

안녕하세요. 노스님. step1에서 주셨던 피드백을 반영하고, step2 요구사항을 구현한 결과를 제출합니다. 😄 

## 질문
빈 의존성배열의 useEffect 내에 window가 unload시 handleUnload 이벤트를 호출하도록 등록했습니다. 그런데 handleUnload에서 불러오는 state 값은 최신화가 되지 않고 초기값에 머물러 있더라구요.

이러한 문제 때문에, 매 렌더링 변화시마다 핸들러를 재생성해서 재등록하는 방법을 사용해보니, state가 최신화되어 localStorage에 저장되어 해결된 것 같더라구요. 그런데 문제는 말 그대로 매 변화시마다 핸들러가 재생성돼서 재등록되니 성능상 문제가 있겠다고 판단됐습니다.

따라서 이를 해결하기 위해 다음과 같이 리팩토링(해당 커밋 [23f9a09](https://github.com/woowacourse/react-calculator/pull/60/commits/23f9a09aaf6b12a0dac64d9ea098b55a81485fdd)) 하였습니다. 해당 커밋에서 볼 수 있듯이, 두 번째 해결방법은 useRef를 이용하여 참조값으로 데이터에 접근하는 방법입니다. 

- [ ] [질문] 리액트에서 window에 이벤트를 등록한 경우, 이벤트핸들러의 콜백함수가 실행될 경우 콜백함수에서 사용하고 있는 state가 최신화되지 않고 왜 초기값에 머물러 있는지 궁금합니다.
- [ ] [질문] useRef를 사용한 두 번째 해결 방법에는 문제가 없을까요? 또는 다른 접근방법이 있는지 궁금합니다.

## step1 피드백 반영
- [x] addEventListner를 componentDidMount 단계에서 하고 removeEventListener를 componentWillUnmount 단계에서 수행
	- https://github.com/woowacourse/react-calculator/pull/26#discussion_r857115046
- [x]  state가 바뀔때마다 발생하는 JSON.stringify연산과 localStorage 접근을 해결(unload 이벤트 발생 시점에 적용)
	- https://github.com/woowacourse/react-calculator/pull/26#discussion_r857117444 
- [x]  여러 setState를 한 번에 해보기
	- https://github.com/woowacourse/react-calculator/pull/26#discussion_r857120171 
	- [refactor: 분리된 state들을 하나의 객체로 구성된 state로 관리](https://github.com/woowacourse/react-calculator/commit/3cba440706d538755431a8aa91128dcc40f5e894)
- [x]  switch문의 결과를 바로 return하기
	-  https://github.com/woowacourse/react-calculator/pull/26#discussion_r857121287
- [x]  sub-rendering 안티 패턴 대신 components로 분리
	- https://github.com/woowacourse/react-calculator/pull/26#discussion_r857126973 	
## step2 요구사항 구현
- [x] Step1의 Class Component를 Function Component로 마이그레이션